### PR TITLE
appropriate handling of '1999 You are not authorized.' dir response

### DIFF
--- a/bareos/bsock/lowlevel.py
+++ b/bareos/bsock/lowlevel.py
@@ -346,8 +346,15 @@ class LowLevel(object):
         except RuntimeError:
             self.logger.error("RuntimeError exception in recv")
             return (0, True, False)
+        
+        # invalid username
+        if ProtocolMessages.is_not_authorized(msg):
+            self.logger.error("failed: " + str(msg))
+            return (0, True, False)
+        
         # check the receive message
         self.logger.debug("(recv): " + str(msg))
+        
         msg_list = msg.split(b" ")
         chal = msg_list[2]
         # get th timestamp and the tle info from director response

--- a/bareos/bsock/protocolmessages.py
+++ b/bareos/bsock/protocolmessages.py
@@ -28,5 +28,13 @@ class ProtocolMessages():
         return b"1999 Authorization failed.\n"
 
     @staticmethod
+    def not_authorized():
+        return b"1999 You are not authorized.\n"
+
+    @staticmethod
     def is_auth_ok(msg):
         return msg == ProtocolMessages.auth_ok()
+
+    @staticmethod
+    def is_not_authorized(msg):
+        return msg == ProtocolMessages.not_authorized()


### PR DESCRIPTION
Hello. I've found that current version of the lib handles some of the director auth responses incorrectly.

If try to connect using existing username and wrong password, all things seem to be work right. For example, following call

```
import bareos.bsock

bareos.bsock.BSockJson(
                address='director_hostname.com',
                port=9999,
                name='good_username',
                password= bareos.bsock.Password('bad_password'))
```

raises an exception as expected:

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    password= bareos.bsock.Password('bad_password'))
  File "/usr/lib/python2.7/site-packages/bareos/bsock/bsockjson.py", line 12, in __init__
    super(BSockJson, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/bareos/bsock/directorconsolejson.py", line 15, in __init__
    super(DirectorConsoleJson, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/bareos/bsock/directorconsole.py", line 19, in __init__
    self.auth(name=name, password=password, auth_success_regex=b'^1000 OK.*$')
  File "/usr/lib/python2.7/site-packages/bareos/bsock/lowlevel.py", line 77, in auth
    return self.__auth()
  File "/usr/lib/python2.7/site-packages/bareos/bsock/lowlevel.py", line 87, in __auth
    raise AuthenticationError("failed (in response)")
bareos.exceptions.AuthenticationError: failed (in response)
```

But if try to sign in to the console using incorrect (i. e. not presented in the director console conf files) username:

```
bareos.bsock.BSockJson(
                address='director_hostname.com',
                port=9999,
                name='unknown_user',
                password= bareos.bsock.Password('bad_password'))
```

we've got ugly implementation-related exception:

```
Traceback (most recent call last):
  File "test.py", line 7, in <module>
    password= bareos.bsock.Password('bad_password'))
  File "/usr/lib/python2.7/site-packages/bareos/bsock/bsockjson.py", line 12, in __init__
    super(BSockJson, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/bareos/bsock/directorconsolejson.py", line 15, in __init__
    super(DirectorConsoleJson, self).__init__(*args, **kwargs)
  File "/usr/lib/python2.7/site-packages/bareos/bsock/directorconsole.py", line 19, in __init__
    self.auth(name=name, password=password, auth_success_regex=b'^1000 OK.*$')
  File "/usr/lib/python2.7/site-packages/bareos/bsock/lowlevel.py", line 77, in auth
    return self.__auth()
  File "/usr/lib/python2.7/site-packages/bareos/bsock/lowlevel.py", line 85, in __auth
    (ssl, result_compatible, result) = self._cram_md5_respond(password=self.password.md5(), tls_remote_need=0)
  File "/usr/lib/python2.7/site-packages/bareos/bsock/lowlevel.py", line 354, in _cram_md5_respond
    ssl = int(msg_list[3][4])
IndexError: bytearray index out of range
```

The reason is that director returns `1999 You are not authorized.` error message right away if provided username is unknown instead of sending `auth cram-md5 <xxx> ssl=0\n` prompt message.

So i've made these changes in order to implement properly handling of the cases like described above. Please check it out.
