### PR TITLE
fix TypeError: a bytes-like object is required, not 'str'

### DIFF
--- a/bareos/bsock/lowlevel.py
+++ b/bareos/bsock/lowlevel.py
@@ -199,7 +199,7 @@ class LowLevel(object):
                         # check for regex in new submsg
                         # and last line in old message,
                         # which might have been incomplete without new submsg.
-                        lastlineindex = self.receive_buffer.rfind('\n') + 1
+                        lastlineindex = self.receive_buffer.rfind(b'\n') + 1
                         self.receive_buffer += submsg
                         match = re.search(regex, self.receive_buffer[lastlineindex:], re.MULTILINE)
                         # Bareos indicates end of command result by line starting with 4 digits


### PR DESCRIPTION
Fixes issue when in python3 user gets following error trying to connect to Director service:

```
>>> import bareos.bsock
>>> password=bareos.bsock.Password(pwd)
>>> directorconsole=bareos.bsock.DirectorConsoleJson(address=host, port=9101, password=password)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/sergey/PycharmProjects/python-bareos-source/bareos/bsock/directorconsolejson.py", line 15, in __init__
    super(DirectorConsoleJson, self).__init__(*args, **kwargs)
  File "/Users/sergey/PycharmProjects/python-bareos-source/bareos/bsock/directorconsole.py", line 19, in __init__
    self.auth(name=name, password=password, auth_success_regex=b'^1000 OK.*$')
  File "/Users/sergey/PycharmProjects/python-bareos-source/bareos/bsock/lowlevel.py", line 77, in auth
    return self.__auth()
  File "/Users/sergey/PycharmProjects/python-bareos-source/bareos/bsock/lowlevel.py", line 90, in __auth
    self.recv_msg(self.auth_success_regex)
  File "/Users/sergey/PycharmProjects/python-bareos-source/bareos/bsock/lowlevel.py", line 202, in recv_msg
    lastlineindex = self.receive_buffer.rfind('\n') + 1
TypeError: a bytes-like object is required, not 'str'
```