### PR TITLE
Fix recv_msg

### DIFF
--- a/bareos/bsock/lowlevel.py
+++ b/bareos/bsock/lowlevel.py
@@ -205,7 +205,7 @@ class LowLevel(object):
                         # Bareos indicates end of command result by line starting with 4 digits
                         if match:
                             self.logger.debug("msg \"{0}\" matches regex \"{1}\"".format(self.receive_buffer.strip(), regex))
-                            result = self.receive_buffer[0:lastlineindex] + self.receive_buffer[lastlineindex:match.end()]
+                            result = self.receive_buffer[0:lastlineindex] + self.receive_buffer[lastlineindex:lastlineindex+match.end()]
                             self.receive_buffer = self.receive_buffer[lastlineindex+match.end()+1:]
                             return result
                         #elif re.search("^\d\d\d\d .*$", msg, re.MULTILINE):


### PR DESCRIPTION
I faced with problem, when i execute 'estimate job=ow-backup03_oracle_manual' i don't get last line.

match = re.search(regex, self.receive_buffer[lastlineindex:], re.MULTILINE)
...
result = self.receive_buffer[0:lastlineindex] + self.receive_buffer[lastlineindex:match.end()]
match.end() returns position relative to lastlineindex, not the begining of self.receive_buffer.